### PR TITLE
refactor mockServer to allow for dynamic pagination and expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@typescript-eslint/eslint-plugin": "^4.14.2",
     "@typescript-eslint/parser": "^4.14.2",
     "babel-eslint": "^10.1.0",
-    "eslint": "^7.19.0",
+    "eslint": "^7.20.0",
     "eslint-config-react-app": "^6.0.0",
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.1",

--- a/src/mockServer.js
+++ b/src/mockServer.js
@@ -1,48 +1,55 @@
-const mockData = [
-  {
-    payments: [
-      { paymentDate: '2020/01/21', paymentAmount: 500, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/21', paymentAmount: 500, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/21', paymentAmount: 500, processedBy: 'HyesunAn' },
-      { paymentDate: '2020/01/12', paymentAmount: 1000, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/12', paymentAmount: 1000, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/12', paymentAmount: 1000, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/10', paymentAmount: 100, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/10', paymentAmount: 100, processedBy: 'JustinWong' }
-    ],
-    totalRows: 18,
-    totalPages: 3,
-    currentPage: 0
-  },
-  {
-    payments: [
-      { paymentDate: '2020/01/10', paymentAmount: 100, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/10', paymentAmount: 25, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/10', paymentAmount: 25, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/10', paymentAmount: 25, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' }
-    ],
-    totalRows: 18,
-    totalPages: 3,
-    currentPage: 1
-  },
-  {
-    payments: [
-      { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' },
-      { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' }
-    ],
-    totalRows: 18,
-    totalPages: 3,
-    currentPage: 2
-  }
-];
+const mockData =   {
+  payments: [
+    { paymentDate: '2020/01/21', paymentAmount: 500, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/21', paymentAmount: 500, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/21', paymentAmount: 500, processedBy: 'HyesunAn' },
+    { paymentDate: '2020/01/12', paymentAmount: 1000, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/12', paymentAmount: 1000, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/12', paymentAmount: 1000, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/10', paymentAmount: 100, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/10', paymentAmount: 100, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/10', paymentAmount: 100, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/10', paymentAmount: 25, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/10', paymentAmount: 25, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/10', paymentAmount: 25, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' },
+    { paymentDate: '2020/01/01', paymentAmount: 125, processedBy: 'JustinWong' }
+  ]
+};
 
-const mockDBCall = (page, rowsPerPage) => {
-  rowsPerPage + 0; // This line is to satisfy es-lint, it will be passed to axios
-  return mockData[page];
+const recordName = {
+  // TODO: enter the record name the DB returns for the record type
+  payments: 'payments'
+};
+
+// ASSUMES: page >=0, rowsPerPage > 0
+const mockDBCall = (key, page, rowsPerPage) => {
+  // Assign an empty array if the key is invalid
+  const data = mockData[key] || [];
+  const totalRows = data.length;
+  const startRow = page * rowsPerPage;
+  const recordTitle = recordName[key];
+
+  const res = {
+    totalRows: totalRows,
+    totalPages: Math.ceil(totalRows/rowsPerPage)    
+  };
+
+  if (startRow < 0 || startRow >= totalRows) {
+    console.log('The requested page does not exist.');
+    res[recordTitle] = [];
+    res.currentPage = 0;
+  } else {
+    const endRow = Math.min(totalRows, startRow + rowsPerPage);
+    res[recordTitle] = data.slice(startRow, endRow);
+    res.currentPage = page;
+  }
+
+  return res;
 };
 
 export { mockDBCall, mockData };

--- a/src/pages/Transactions.js
+++ b/src/pages/Transactions.js
@@ -3,9 +3,8 @@ import { React, useState } from 'react';
 import PaymentsTable from '../components/PaymentsTable';
 import { getPaymentHistory } from '../services/PaymentsService';
 
-const rowsPerPage = 8;
-
 const Transactions = () => {
+  const [rowsPerPage] = useState(8);
   const [paymentHistory, setPaymentHistory] = useState(getPaymentHistory(0, rowsPerPage));
 
   const handleChangePage = (page) => {

--- a/src/services/PaymentsService.js
+++ b/src/services/PaymentsService.js
@@ -3,7 +3,7 @@ import { mockDBCall } from '../mockServer';
 
 const getPaymentHistory = (page, rowsPerPage) => {
   // TODO: Replace with API Call (Ticket: SNAK-126)
-  return mockDBCall(page, rowsPerPage);
+  return mockDBCall('payments', page, rowsPerPage);
 };
 
 export { getPaymentHistory };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
+"@babel/code-frame@7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/compat-data@^7.12.1", "@babel/compat-data@^7.12.5", "@babel/compat-data@^7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.7.tgz#9329b4782a7d6bbd7eef57e11addf91ee3ef1e41"
@@ -4862,12 +4869,12 @@ eslint@^7.11.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^7.19.0:
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.19.0.tgz#6719621b196b5fad72e43387981314e5d0dc3f41"
-  integrity sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==
+eslint@^7.20.0:
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.20.0.tgz#db07c4ca4eda2e2316e7aa57ac7fc91ec550bdc7"
+  integrity sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==
   dependencies:
-    "@babel/code-frame" "^7.0.0"
+    "@babel/code-frame" "7.12.11"
     "@eslint/eslintrc" "^0.3.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
@@ -4879,7 +4886,7 @@ eslint@^7.19.0:
     eslint-utils "^2.1.0"
     eslint-visitor-keys "^2.0.0"
     espree "^7.3.1"
-    esquery "^1.2.0"
+    esquery "^1.4.0"
     esutils "^2.0.2"
     file-entry-cache "^6.0.0"
     functional-red-black-tree "^1.0.1"
@@ -4932,6 +4939,13 @@ esquery@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
   integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
+  dependencies:
+    estraverse "^5.1.0"
+
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 


### PR DESCRIPTION
Implemented a simple refactor so the mock server could be extended for other DB calls beyond payments. (e.g. users, snacks, etc.). 
- Implemented dynamic pagination so mock records did not have to be hard coded with pagination
- Fixed breaking changes in the codebase (all regarding Payments/Transactions)

[Jira link](https://team-1600642168705.atlassian.net/browse/SNAK-138?atlOrigin=eyJpIjoiYjFlOWU1NTdiNGZkNGIxM2IyYTM5OGY2ODM1Y2ZmYTAiLCJwIjoiaiJ9)