### PR TITLE
SNAK-171: Some fonts not appearing in Firefox

### DIFF
--- a/src/styles/Category.module.css
+++ b/src/styles/Category.module.css
@@ -81,7 +81,6 @@
 
 .icon_button {
 	width: 100%;
-	height: 100%;
 }
 
 .filter_hover {


### PR DESCRIPTION
- Fonts are visible - text was just pushed outside of the container for the svg because I initially set `height: 100%`

<img width="988" alt="Screen Shot 2021-02-19 at 10 57 55 PM" src="https://user-images.githubusercontent.com/44279603/108587068-6bc4f500-7306-11eb-8aa5-f9a7db2544fc.png">
![Screen Shot 2021-02-19 at 10 58 31 PM](https://user-images.githubusercontent.com/44279603/108587080-72536c80-7306-11eb-8371-058548cc0709.png)
