### PR TITLE
SNAK-212-Fixed Infinite Progress on Login Error/Cancel

### DIFF
--- a/src/helpers/AuthLoginHelper.js
+++ b/src/helpers/AuthLoginHelper.js
@@ -1,7 +1,3 @@
-const loginFailure = (res) => {
-  console.log('[Login Failed] currentUser: ', res);
-};
-
 const refreshTokenSetup = (res) => {
   let refreshTiming = (res.tokenObj.expires_in || 3600 - 5 * 60) * 1000;
 
@@ -15,4 +11,4 @@ const refreshTokenSetup = (res) => {
   setTimeout(refreshToken, refreshTiming);
 };
 
-export { refreshTokenSetup, loginFailure };
+export { refreshTokenSetup };

--- a/src/pages/AuthLogin.js
+++ b/src/pages/AuthLogin.js
@@ -1,10 +1,10 @@
 import { Button, Card, CircularProgress } from '@material-ui/core';
 import React, { useState } from 'react';
-import { loginFailure, refreshTokenSetup } from '../helpers/AuthLoginHelper';
 
 import GalvanizeLogo from '../images/logo/galvanize.svg';
 import appStyles from '../styles/SnackTrack.module.css';
 import { authenticate } from '../services/UsersService';
+import { refreshTokenSetup } from '../helpers/AuthLoginHelper';
 import { setUser } from '../redux/features/users/usersSlice';
 import styles from '../styles/Login.module.css';
 import { useDispatch } from 'react-redux';
@@ -24,6 +24,11 @@ const AuthLogin = () => {
     setProfile(userResponse);
     refreshTokenSetup(googleUser);
     history.push('/snacks');
+  };
+
+  const loginFailure = (res) => {
+    setIsLoading(false);
+    console.log('[Login Failed] currentUser: ', res);
   };
 
   const { signIn } = useGoogleLogin({


### PR DESCRIPTION
Previously, the progress indicator would persist even if a user closes login or fails to login.

Changes made now change indicator back to text on login failure.


https://user-images.githubusercontent.com/32123388/108641943-0a606b80-7457-11eb-9db6-c8cc288e74ed.mov

@adimatulac @anhyesun @lbisceglia 