### PR TITLE
Fix: OrderSnackDialog image sizing

### DIFF
--- a/src/styles/Dialog.module.css
+++ b/src/styles/Dialog.module.css
@@ -2,7 +2,7 @@
 @value LIGHT_GREY, MID_GREY, DARK_GREY, LIGHT_BLUE, BASE_BLUE, BASE_BLUE_HOVER, DARK_BLUE from colors;
 
 .card {
-  max-width: 360px;
+  max-width: 300px;
   display: flex;
   flex-direction: column;
 }
@@ -52,7 +52,8 @@
 }
 
 .image {
-  height: 100%;
+  max-width: 250px;
+  max-height: 250px;
   margin-left: auto;
   margin-right: auto;
   display: flex;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -128,6 +128,11 @@ export const theme = createMuiTheme({
       current: {
         color: BASE_BLUE
       }
+    },
+    MuiDialog: {
+      paper: {
+        borderRadius: '12px'
+      }
     }
   },
   props: {


### PR DESCRIPTION
**Issues:**
- If image it too large for page, the dialog gets cut off
- On mobile, it looks horrendous

**Changes:**
- Added fixed width and height for image container - will probably be adjusted again when we implement image upload for snack forms

![Screen Shot 2021-03-11 at 4 56 32 PM](https://user-images.githubusercontent.com/44279603/110875780-205d9100-828b-11eb-98a0-8c1391345ca9.png)
