### PR TITLE
SNAK-307-Fix Checkbox Bug

### DIFF
--- a/src/components/OrdersTable/OrdersTable.js
+++ b/src/components/OrdersTable/OrdersTable.js
@@ -34,12 +34,12 @@ const Orders = (props) => {
   };
 
   const clearLocalStates = () => {
-    setSelectedOrders([]);
-    setSelectedPages([]);
     setSubtotalAmount(0);
     setPayForOrdersDisabled(true);
     setUncheckedOrders([]);
     setUncheckedOrdersIds([]);
+    setSelectedOrders([]);
+    setSelectedPages([]);
   };
 
   const handlePayForOrders = async () => {


### PR DESCRIPTION
Previously, selecting "select all" and making a payment would cause the "select all" checkbox to be unselectable. This has been fixed so that it is selectable again after payment.

@adimatulac @anhyesun @lbisceglia 