### PR TITLE
Fix: Removed hook dependencies to prevent unnecessary rerenders

### DIFF
--- a/src/pages/Users.js
+++ b/src/pages/Users.js
@@ -23,7 +23,7 @@ const Users = () => {
     const { users } = await getUsersAdmin();
     setUsers(users);
     setIsLoaded(users.length > 0);
-  }, [users]);
+  }, []);
 
   useEffect(() => {
     handleSearch(users, usersSearchValue, setUsersToDisplay, searchOptions);


### PR DESCRIPTION
Previously after the redesign Users page's useEffect hook would be triggered in a loop, continuously making the API call to get users.