### PR TITLE
Reorder snacks by stock quantity

### DIFF
--- a/src/components/SnacksList/SnacksContainer.js
+++ b/src/components/SnacksList/SnacksContainer.js
@@ -1,4 +1,3 @@
-import { DEFAULT_ORDER_THRESHOLD, TRANSACTION_TYPES } from '../../constants';
 import { React, useEffect, useState } from 'react';
 import { selectOneSnack, setQuantity } from '../../redux/features/snacks/snacksSlice';
 import { useDispatch, useSelector } from 'react-redux';
@@ -6,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import CategoryFilter from './CategoryFilter';
 import OrderSnackDialog from '../OrderSnackDialog';
 import SnackGrid from './SnackGrid';
+import { TRANSACTION_TYPES } from '../../constants';
 import { handleSearch } from '../../helpers/SearchHelpers';
 import { isAuthenticated } from '../../helpers/AuthHelper';
 import { makeOrder } from '../../services/TransactionsService';
@@ -89,14 +89,15 @@ const SnacksContainer = (props) => {
   };
 
   const compareSnacks = (a, b) => {
-    const aDiff = a.quantity - (a.order_threshold || DEFAULT_ORDER_THRESHOLD);
-    const bDiff = b.quantity - (b.order_threshold || DEFAULT_ORDER_THRESHOLD);
-    if (aDiff > 0 || bDiff > 0) {
-      // There is at least one snack with high stock, put it first
-      return bDiff - aDiff;
+    if (a.quantity > 0 && b.quantity <= 0) {
+      // A is in stock and B is not
+      return -1;
+    } else if (a.quantity <= 0 && b.quantity > 0) {
+      // B is in stock and A is not
+      return 1;
     } else {
-      // Order descending by quantity
-      return b.quantity - a.quantity;
+      // otherwise maintain ordering
+      return 0;
     }
   };
 


### PR DESCRIPTION
- Ordered snacks by quantity/stock status so that users are not confronted with so many Out of Stock snacks which are unactionable to them.
- This ordering is maintained when filtering
- Searching overrides this ordering since the items are ordered by keyword match

![Screenshot_2021-04-06 SnackTrack(2)](https://user-images.githubusercontent.com/11357711/113774890-bba42380-96dc-11eb-98ac-641056e4e70f.png)
