### PR TITLE
fix for persistent image upload

### DIFF
--- a/src/components/AddSnackDialog.js
+++ b/src/components/AddSnackDialog.js
@@ -82,7 +82,6 @@ const AddSnackDialog = (props) => {
     setExpiryDate(null);
     addForm.resetForm();
     setIsBatchDetailsOpen(false);
-    dispatch(setSnackImageUploadData(null));
   }, [isAddSnackOpen]);
 
   const addForm = useFormik({
@@ -114,6 +113,7 @@ const AddSnackDialog = (props) => {
         onHandleApiResponse('ERROR');
       }
       actions.resetForm({ values: initialState });
+      dispatch(setSnackImageUploadData(null));
       setIsSubmitLoading(false);
       closeDialog();
     },

--- a/src/components/EditSnackDialog.js
+++ b/src/components/EditSnackDialog.js
@@ -5,6 +5,7 @@ import { Dialog, Divider, Switch } from '@material-ui/core';
 import { Form, FormikProvider, useFormik } from 'formik';
 import { React, useEffect, useState } from 'react';
 import { deleteSnack, editSnack } from '../services/SnacksService';
+import { setIsEditSnackOpen, setSnackImageUploadData } from '../redux/features/snacks/snacksSlice';
 import { useDispatch, useSelector } from 'react-redux';
 
 import AppButton from './AppButton';
@@ -15,7 +16,6 @@ import InputLiveFeedback from './ManageSnack/InputLiveFeedback';
 import TextAreaField from './TextAreaField';
 import dialogStyles from '../styles/Dialog.module.css';
 import { saveImage } from '../services/ImagesService';
-import { setIsEditSnackOpen } from '../redux/features/snacks/snacksSlice';
 import styles from '../styles/ManageSnack.module.css';
 
 const options = CATEGORIES_LIST.map((category) => ({
@@ -120,6 +120,7 @@ const EditSnackDialog = (props) => {
         onHandleApiResponse('ERROR');
       }
       actions.resetForm({ values: blankState });
+      dispatch(setSnackImageUploadData(null));
       setIsSubmitLoading(false);
       closeDialog();
     },


### PR DESCRIPTION
**Issue:**
- I uploaded a new snack with an image then edited a current snack; when I hit save the image from my previous snack upload replaced the current snack image
- We weren't clearing the image upload state after submitting/saving

![Screen Shot 2021-04-12 at 7 53 22 AM](https://user-images.githubusercontent.com/44279603/114417656-a0b33280-9b66-11eb-87b2-eca55fd4ddbd.png)
