### PR TITLE
SNAK-433 sort snacks list alphabetically

### DIFF
--- a/src/components/SnacksList/SnacksContainer.js
+++ b/src/components/SnacksList/SnacksContainer.js
@@ -95,6 +95,10 @@ const SnacksContainer = (props) => {
   };
 
   const compareSnacks = (a, b) => {
+    return compareSnackStock(a, b) || compareSnackNames(a, b);
+  };
+
+  const compareSnackStock = (a, b) => {
     if (a.quantity > 0 && b.quantity <= 0) {
       // A is in stock and B is not
       return -1;
@@ -105,6 +109,10 @@ const SnacksContainer = (props) => {
       // otherwise maintain ordering
       return 0;
     }
+  };
+
+  const compareSnackNames = (a, b) => {
+    return a.snack_name.localeCompare(b.snack_name);
   };
 
   useEffect(() => {


### PR DESCRIPTION
Change the sort ordering so snacks are sorted alphabetically.
- This makes it easier to navigate for a particular item when no filters/searches are used
- Filters and searches still work as expected
- Out of stock snacks still appear at the bottom, also alphabetically

![Screenshot_2021-04-24 SnackTrack(1)](https://user-images.githubusercontent.com/11357711/115972485-62712800-a503-11eb-8d25-71eb5620228b.png)

[Jira Ticket](https://team-1600642168705.atlassian.net/secure/RapidBoard.jspa?rapidView=2&projectKey=SNAK&selectedIssue=SNAK-433&assignee=5f67dc5258ea7b007058600d)