### PR TITLE
SNAK-434 make searches stricter and order users alphabetically

### DIFF
--- a/src/components/AddBatchSelect.js
+++ b/src/components/AddBatchSelect.js
@@ -7,6 +7,7 @@ import {
 } from '../styles/Colors.module.css';
 import { React, useEffect, useState } from 'react';
 
+import { DEFAULT_SEARCH_THRESHOLD } from '../constants';
 import Select from 'react-select';
 import { handleSearch } from '../helpers/SearchHelpers';
 
@@ -16,7 +17,8 @@ const AddBatchSelect = (props) => {
   const [searchedOptions, setSearchedOptions] = useState([]);
 
   const searchOptions = {
-    keys: ['label']
+    keys: ['label'],
+    threshold: DEFAULT_SEARCH_THRESHOLD
   };
 
   useEffect(() => {

--- a/src/components/ShoppingListDropDown.js
+++ b/src/components/ShoppingListDropDown.js
@@ -7,6 +7,7 @@ import {
 } from '../styles/Colors.module.css';
 import { React, useEffect, useState } from 'react';
 
+import { DEFAULT_SEARCH_THRESHOLD } from '../constants';
 import Select from 'react-select';
 import { handleSearch } from '../helpers/SearchHelpers';
 
@@ -16,7 +17,8 @@ const ShoppingListDropDown = (props) => {
   const [searchedOptions, setSearchedOptions] = useState([]);
 
   const searchOptions = {
-    keys: ['label']
+    keys: ['label'],
+    threshold: DEFAULT_SEARCH_THRESHOLD
   };
 
   useEffect(() => {

--- a/src/components/SnacksList/SnacksContainer.js
+++ b/src/components/SnacksList/SnacksContainer.js
@@ -1,3 +1,4 @@
+import { DEFAULT_SEARCH_THRESHOLD, TRANSACTION_TYPES } from '../../constants';
 import { React, useEffect, useState } from 'react';
 import { selectOneSnack, setQuantity } from '../../redux/features/snacks/snacksSlice';
 import { setBalance, setSessionBalance } from '../../redux/features/users/usersSlice';
@@ -6,7 +7,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import CategoryFilter from './CategoryFilter';
 import OrderSnackDialog from '../OrderSnackDialog';
 import SnackGrid from './SnackGrid';
-import { TRANSACTION_TYPES } from '../../constants';
 import { handleSearch } from '../../helpers/SearchHelpers';
 import { isAuthenticated } from '../../helpers/AuthHelper';
 import { makeOrder } from '../../services/TransactionsService';
@@ -27,7 +27,8 @@ const SnacksContainer = (props) => {
   const { snackSearchValue } = useSelector((state) => state.searchbarReducer);
 
   const searchOptions = {
-    keys: ['snack_name']
+    keys: ['snack_name'],
+    threshold: DEFAULT_SEARCH_THRESHOLD
   };
 
   const updateSnackQuantity = (snackId, newQuantity) => {

--- a/src/components/UserLoginList.js
+++ b/src/components/UserLoginList.js
@@ -6,7 +6,25 @@ const UserLoginList = (props) => {
 
   const {users} = props;
 
-  const userCards = users.map((user) => <UserCard key={user.user_id} user={user}/>);
+  const compareUsers = (a, b) => {
+    return compareName(a,b) || compareAdmin(a,b);
+  };
+
+  const compareName = (a, b) => {
+    return a.full_name.localeCompare(b.full_name);
+  };
+
+  const compareAdmin = (a, b) => {
+    if (a.is_admin && !b.is_admin) {
+      return -1;
+    } else if (!a.is_admin && b.is_admin) {
+      return 1;
+    } else {
+      return 0;
+    }
+  };
+
+  const userCards = users.sort(compareUsers).map((user) => <UserCard key={user.user_id} user={user}/>);
   const visibleUserCards = userCards.slice(0, 8);
 
   return (

--- a/src/constants.js
+++ b/src/constants.js
@@ -26,6 +26,8 @@ export const DEFAULT_CATEGORIES = {
   OTHER: 'Other'
 };
 
+export const DEFAULT_SEARCH_THRESHOLD = 0.25;
+
 export const CATEGORIES_LIST = [
   {
     id: 1,

--- a/src/pages/SelectLogin.js
+++ b/src/pages/SelectLogin.js
@@ -1,6 +1,6 @@
 import { React, useEffect, useState } from 'react';
 
-import { NOTIFICATIONS } from '../constants';
+import { DEFAULT_SEARCH_THRESHOLD, NOTIFICATIONS } from '../constants';
 import { ReactComponent as SnackTrackLogo } from '../assets/logos/snacktrack.svg';
 import UserCardSkeleton from '../components/UserCard/UserCardSkeleton';
 import UserLoginList from '../components/UserLoginList';
@@ -17,8 +17,13 @@ const SelectLogin = () => {
   const [usersToDisplay, setUsersToDisplay] = useState(users);
   const { usersSearchValue } = useSelector((state) => state.searchbarReducer);
 
+  users.forEach(user => {
+    user.full_name = `${user.first_name} ${user.last_name}`;
+  });
+
   const searchOptions = {
-    keys: ['first_name', 'last_name', 'email_address']
+    keys: ['full_name', 'email_address'],
+    threshold: DEFAULT_SEARCH_THRESHOLD
   };
 
   const renderList = () => {


### PR DESCRIPTION
- Made searches stricter so that smaller typos are allowed, fewer results are returned
- Sorted user lists alphabetically in common login and Users
- Allowed searches to be done on the combined first name + last name field (instead of just one or the other)

I recommend you play with it to see if the changes are satisfactory.

![image](https://user-images.githubusercontent.com/11357711/115973593-132ef580-a50b-11eb-88a0-d4d813effeff.png)
![image](https://user-images.githubusercontent.com/11357711/115973585-0b6f5100-a50b-11eb-9eac-b4d267206ae3.png)
![image](https://user-images.githubusercontent.com/11357711/115973604-2e016a00-a50b-11eb-8543-acffe1f59152.png)
![image](https://user-images.githubusercontent.com/11357711/115973611-3e194980-a50b-11eb-8859-bd016e6a8ec2.png)

